### PR TITLE
Fix a bug that wrongly dispatched compute to cpu

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -7,7 +7,7 @@ jobs:
   run-test-suite:
     name: Run test suite
     runs-on: ubuntu-latest
-    container: python:latest
+    container: python:3.11
       # TODO: use a gpu-compatible image, setup runners with a compatible gpu and activate
       # gpu passthrough options
 

--- a/sklearn_pytorch_engine/_utils.py
+++ b/sklearn_pytorch_engine/_utils.py
@@ -24,10 +24,7 @@ def get_torch_default_device():
 
 
 def get_sklearn_pytorch_engine_default_device():
-    device = os.getenv("SKLEARN_PYTORCH_ENGINE_DEFAULT_DEVICE", None)
-    if device is None:
-        device = get_torch_default_device()
-    return device
+    return os.getenv("SKLEARN_PYTORCH_ENGINE_DEFAULT_DEVICE", None)
 
 
 @lru_cache


### PR DESCRIPTION
It only used the device set by SKLEARN_PYTORCH_ENGINE_DEFAULT_DEVICE and always CPU if not set.
